### PR TITLE
Update selector for readable font family

### DIFF
--- a/src/assets/scss/components/_accessibility.scss
+++ b/src/assets/scss/components/_accessibility.scss
@@ -5,7 +5,6 @@ html {
         }
     }
     &.sx-accessibility--readable-font {
-        *:not([class^='icon-']),
         *:not([class*='icon-']) {
             font-family: Arial, Helvetica, sans-serif !important;
         }


### PR DESCRIPTION
Due to PrimeVue forcing its own class on first spot, our icons are also overwritten with Arial font.

![image](https://github.com/Sarosh90/sx-accessibility/assets/22049682/7ffb3e73-5ce7-4c50-879a-dc760ca4f9e8)

With the change, it looks for `icon-` anywhere is class and it works well:
https://i.imgur.com/gr1KAgg.gif

Let me know if you find the change questionable or would do it differently.